### PR TITLE
Use `NonEmptyArray` as argument for `Choice`

### DIFF
--- a/src/non-empty-array.ts
+++ b/src/non-empty-array.ts
@@ -1,0 +1,4 @@
+export type NonEmptyArray<T> = [T, ...T[]];
+
+export const isNonEmptyArray = <T>(candidate: T[]): candidate is NonEmptyArray<T> =>
+  candidate.length > 0;

--- a/src/random.ts
+++ b/src/random.ts
@@ -1,12 +1,11 @@
 import { NonEmptyArray } from "./non-empty-array";
 
 export type Coin = () => boolean;
-export type CoinFlip = (flip: Coin) => () => boolean;
+export type CoinFlip = (f: Coin) => () => boolean;
 
 export const fairCoin: Coin = () => Math.random() < 0.5;
 export const falseCoin: Coin = () => false;
 export const trueCoin: Coin = () => true;
-
 export const coinFlip: CoinFlip = (flip) => () => flip();
 
 export const memoryCoin = (start: boolean, remembers: number = 2): Coin => {
@@ -15,7 +14,7 @@ export const memoryCoin = (start: boolean, remembers: number = 2): Coin => {
 
   return () => {
     if (remembers < 0) {
-      throw new Error("remembers must be an integer or zero");
+      throw new Error("remembers must be a positive integer or zero");
     }
 
     const result = next;
@@ -27,9 +26,7 @@ export const memoryCoin = (start: boolean, remembers: number = 2): Coin => {
 };
 
 export type Choice = <T>(xs: NonEmptyArray<T>) => T;
-export type Choose = <T>(
-  choice: (xs: NonEmptyArray<T>) => T
-) => (options: NonEmptyArray<T>) => T;
+export type Choose = <T>(f: (xs: NonEmptyArray<T>) => T) => (xs: NonEmptyArray<T>) => T;
 
 export const choose: Choose = (f) => (l) => f(l);
 export const fairChoice: Choice = (xs) => xs[getRandomInt(0, xs.length - 1)];

--- a/src/random.ts
+++ b/src/random.ts
@@ -1,4 +1,4 @@
-import { none, Option, some } from "./option";
+import { NonEmptyArray } from "./non-empty-array";
 
 export type Coin = () => boolean;
 export type CoinFlip = (flip: Coin) => () => boolean;
@@ -29,30 +29,15 @@ export const memoryCoin = (start: boolean, remembers: number = 2): MemoryCoin =>
   };
 };
 
-export type Choice = <T>(xs: T[]) => Option<T>;
-export type ChooseFirst = Choice;
-export type ChooseLast = Choice;
-export type Choose = <T>(choice: (xs: T[]) => Option<T>) => (options: T[]) => Option<T>;
+export type Choice = <T>(xs: NonEmptyArray<T>) => T;
+export type Choose = <T>(
+  choice: (xs: NonEmptyArray<T>) => T
+) => (options: NonEmptyArray<T>) => T;
 
 export const choose: Choose = (f) => (l) => f(l);
-
-export const fairChoice: Choice = (xs) => {
-  if (xs.length === 0) {
-    return none;
-  }
-  const index = getRandomInt(0, xs.length - 1);
-  return some(xs[index]);
-};
-
-export const chooseFirst: ChooseFirst = (xs) => {
-  const [first] = xs;
-  return first === undefined ? none : some(first);
-};
-
-export const chooseLast: ChooseLast = (xs) => {
-  const last = xs[xs.length - 1];
-  return last === undefined ? none : some(last);
-};
+export const fairChoice: Choice = (xs) => xs[getRandomInt(0, xs.length - 1)];
+export const chooseFirst: Choice = (xs) => xs[0];
+export const chooseLast: Choice = (xs) => xs[xs.length - 1];
 
 /**
  * Returns a random integer between min (inclusive) and max (inclusive).

--- a/src/random.ts
+++ b/src/random.ts
@@ -2,17 +2,14 @@ import { NonEmptyArray } from "./non-empty-array";
 
 export type Coin = () => boolean;
 export type CoinFlip = (flip: Coin) => () => boolean;
-export type UnfairCoin = Coin;
-export type FairCoin = Coin;
-export type MemoryCoin = Coin;
 
-export const fairCoin: FairCoin = () => Math.random() < 0.5;
-export const falseCoin: UnfairCoin = () => false;
-export const trueCoin: UnfairCoin = () => true;
+export const fairCoin: Coin = () => Math.random() < 0.5;
+export const falseCoin: Coin = () => false;
+export const trueCoin: Coin = () => true;
 
 export const coinFlip: CoinFlip = (flip) => () => flip();
 
-export const memoryCoin = (start: boolean, remembers: number = 2): MemoryCoin => {
+export const memoryCoin = (start: boolean, remembers: number = 2): Coin => {
   let next = start;
   let count = 0;
 


### PR DESCRIPTION
Is the caller's responsibility to ensure the argument is of the correct type in runtime. This check can be performed using `isNonEmptyArray`, defined in `src/non-empty-array.ts`:

```typescript
const foo = []
isNonEmptyArray(foo) // false

const bar = [0]
isNonEmptyArray(bar) // true
```

Also, I removed all the redundant `Coin` types and the redundant `Choice` types.